### PR TITLE
Passing Tailwind classes via props mistake

### DIFF
--- a/components/ui/Buttons.tsx
+++ b/components/ui/Buttons.tsx
@@ -15,7 +15,8 @@ export const GreenBtn = ({
   return (
     <button
       onClick={onEventBtn}
-      className={`btn ${mt} drop-shadow-md rounded-sm bg-green hover:bg-lightGreen transition-all`}
+      className='btn drop-shadow-md rounded-sm bg-green hover:bg-lightGreen transition-all'
+      style={{marginTop: mt}}
     >
       {text}
     </button>
@@ -31,8 +32,9 @@ interface BorderProps {
 export const BorderBtn = ({ onEventBtn, text, mt }: BorderProps) => {
   return (
     <button
-      className={`mt-[${mt}]px btn bg-transparent border-[1px] border-navyBlue4 rounded-sm`}
       onClick={onEventBtn}
+      className='btn bg-transparent border-[1px] border-navyBlue4 rounded-sm'
+      style={{marginTop: mt}}
     >
       {text}
     </button>


### PR DESCRIPTION
Passing Tailwind classes via props will lead to unexpected behavior, and is not recommended by Tailwind.

Either use [tailwind-merge](https://www.npmjs.com/package/tailwind-merge) + [clsx](https://www.npmjs.com/package/clsx) or set the properties with `style`.

I change your code for the `style` option.